### PR TITLE
Avoid filename collisions with an index prefix

### DIFF
--- a/leccap_dl.py
+++ b/leccap_dl.py
@@ -159,7 +159,7 @@ def main():
 		lec_name = true_urls[i][1]
 		# remove bad characters from lecture filename
 		lec_name = re.sub('[;/?:"=|*]','-',lec_name)
-		filename =  output_directory + '/' + lec_name + FILE_EXT
+		filename = f"{output_directory}/{i}_{lec_name}{FILE_EXT}"
 		if args.threaded:
 			threads.append(threading.Thread(target=download_file, args=(filename, video_urls[i])))
 		else:


### PR DESCRIPTION
In one of my classes, I had a recorded discussion section on the same day as the lecture, which caused many pairs of videos to have the same filename. Consequently, leccap would download both but the second download would overwrite the first.

This change adds an index to the beginning of the filename so name collisions will not happen.